### PR TITLE
fix bug

### DIFF
--- a/src/EdgeGPT.py
+++ b/src/EdgeGPT.py
@@ -99,7 +99,7 @@ class ChatHubRequest:
                 "enable_debug_commands",
                 "disable_emoji_spoken_text",
                 "enablemm",
-                conversation_style.value,
+                conversation_style,
             ]
         self.struct = {
             "arguments": [


### PR DESCRIPTION
```
  File "/opt/homebrew/lib/python3.10/site-packages/EdgeGPT.py", line 102, in update
    conversation_style.value,
AttributeError: 'str' object has no attribute 'value'
```
The above error occurred in version 0.0.54