### PR TITLE
docs: Update README to mention Bing chat on other browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ python3 -m pip install EdgeGPT --upgrade
 
 ### Requirements
 - python 3.8+
-- A Microsoft Account with early access to http://bing.com/chat (Required)
+- A Microsoft Account with early access to <https://bing.com/chat> (Required)
 
 
 <details>
@@ -51,7 +51,8 @@ python3 -m pip install EdgeGPT --upgrade
   </summary>
 
 - Install the latest version of Microsoft Edge
-- Open http://bing.com/chat
+- Alternatively, you can use any browser and set the user-agent to look like you're using Edge (e.g., `Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36 Edg/109.0.1474.0`). You can do this easily with an extension like "User-Agent Switcher and Manager" for [Chrome](https://chrome.google.com/webstore/detail/user-agent-switcher-and-m/bhchdcejhohfmigjafbampogmaanbfkg) and [Firefox](https://addons.mozilla.org/en-US/firefox/addon/user-agent-string-switcher/).
+- Open [bing.com/chat](https://bing.com/chat)
 - If you see a chat feature, you are good to go
 
 </details>


### PR DESCRIPTION
This updates the README "check access" section to inform users they can also use other browsers to check Bing access.

closes #157 