### PR TITLE
Remove asyncio from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-asyncio
 requests
 rich
 websockets


### PR DESCRIPTION
https://pypi.org/project/asyncio/
The asyncio module is part of the Python standard library since Python 3.4.