### PR TITLE
fix 'MissingSchema: Invalid URL' issue

### DIFF
--- a/src/ImageGen.py
+++ b/src/ImageGen.py
@@ -82,15 +82,18 @@ class ImageGen:
         except FileExistsError:
             pass
         image_num = 0
-        for link in links:
-            with self.session.get(link, stream=True) as response:
-                # save response to file
-                response.raise_for_status()
-                with open(f"{output_dir}/{image_num}.jpeg", "wb") as output_file:
-                    for chunk in response.iter_content(chunk_size=8192):
-                        output_file.write(chunk)
+        try:
+            for link in links:
+                with self.session.get(link, stream=True) as response:
+                    # save response to file
+                    response.raise_for_status()
+                    with open(f"{output_dir}/{image_num}.jpeg", "wb") as output_file:
+                        for chunk in response.iter_content(chunk_size=8192):
+                            output_file.write(chunk)
 
-            image_num += 1
+                image_num += 1
+        except requests.exceptions.MissingSchema as url_exception:
+            raise Exception('Inappropriate contents found in the generated images. Please try again or try another prompt.') from url_exception
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
fix 'requests.exceptions.MissingSchema: Invalid URL' issue
![](https://images.weserv.nl/?url=https://img-blog.csdnimg.cn/66d2a12dab0c423da5d7594c90fcfbca.jpeg)