### PR TITLE
Remove unused dependency. Fixes #226

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 certifi
 httpx
 prompt_toolkit
-regex
 requests
 rich
 websockets

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ setup(
         "rich",
         "certifi",
         "prompt_toolkit",
-        "regex",
         "requests",
         "BingImageCreator>=0.1.1.1",
     ],


### PR DESCRIPTION
The `regex` module is removed since its usage in the `../src/ImageGen.py` module had been depreciated and replaced with a more robust library, `BingImageCreator`.

![image](https://user-images.githubusercontent.com/72922139/230832242-9be04746-4f9f-417f-ab64-e87bf210fe61.png)
