### PR TITLE
Refactor

### DIFF
--- a/src/EdgeGPT.py
+++ b/src/EdgeGPT.py
@@ -685,7 +685,7 @@ def main() -> None:
         help="prompt to start with",
     )
     args = parser.parse_args()
-    if args.cookie_file == "":
+    if not args.cookie_file:
         parser.print_help()
         parser.exit(
             1,


### PR DESCRIPTION
`args.cookie_file == ""` can be simplified to `not args.cookie_file` as an empty string is falsey