### PR TITLE
Do not ensure_ascii when encoding message

### DIFF
--- a/src/EdgeGPT.py
+++ b/src/EdgeGPT.py
@@ -155,7 +155,7 @@ def _append_identifier(msg: dict) -> str:
     Appends special character to end of message to identify end of message
     """
     # Convert dict to json string
-    return json.dumps(msg) + DELIMITER
+    return json.dumps(msg, ensure_ascii=False) + DELIMITER
 
 
 def _get_ran_hex(length: int = 32) -> str:


### PR DESCRIPTION
New bing may refuse to respond a message which contains encoded version of non-ascii message.

eg.
<img width="1156" alt="截屏2023-04-25 10 34 12" src="https://user-images.githubusercontent.com/13777628/234160730-093d6532-9e53-474c-8027-89b9eea22e91.png">
<img width="1218" alt="截屏2023-04-25 10 33 45" src="https://user-images.githubusercontent.com/13777628/234160736-45c91dad-684b-47da-a90c-39b1e5955a68.png">

So it seems we should not encode them.