### PR TITLE
GET Request retries

### DIFF
--- a/src/EdgeGPT.py
+++ b/src/EdgeGPT.py
@@ -361,10 +361,12 @@ class _Conversation:
         )
         if proxy is not None and proxy.startswith("socks5h://"):
             proxy = "socks5://" + proxy[len("socks5h://") :]
+        transport = httpx.AsyncHTTPTransport(retries=10)
         async with httpx.AsyncClient(
             proxies=proxy,
             timeout=30,
             headers=HEADERS_INIT_CONVER,
+            transport=transport,
         ) as client:
             for cookie in cookies:
                 client.cookies.set(cookie["name"], cookie["value"])


### PR DESCRIPTION
I'm running script on autostart and my DHCP service is still initializing, producing following error:
```
ValueError: ''edgeservices.bing.com' does not appear to be an IPv4 or IPv6 address
...
... line 376, in create
response = await client.get(
           ^^^^^^^^^^^^^^^^
```

Allowing client to retry a few times solves my problem
