### PR TITLE
fixed bug: sent 1011 (unexpected error) keepalive ping timeout; no cl…

### DIFF
--- a/src/EdgeGPT.py
+++ b/src/EdgeGPT.py
@@ -444,6 +444,7 @@ class _ChatHub:
             headers=HEADERS,
             ssl=ssl_context,
             proxy=self.proxy,
+            ping_interval=None,
         )
         await self._initial_handshake()
         if self.request.invocation_id == 0:


### PR DESCRIPTION
…ose frame received

When the 135th stream message is obtained from ask_stream, an error will be reported: sent 1011 (unexpected error) keepalive ping timeout; no close frame received. I used the method in this link to fix this problem: https://stackoverflow.com/questions/67810506/websockets-exceptions-connectionclosederror-code-1011-unexpected-error-no