### PR TITLE
Still fix cookie lost when reset()

### DIFF
--- a/src/EdgeGPT.py
+++ b/src/EdgeGPT.py
@@ -696,7 +696,7 @@ class Chatbot:
         """
         await self.close()
         self.chat_hub = _ChatHub(
-            await _Conversation.create(self.proxy),
+            await _Conversation.create(self.proxy, cookies=self.chat_hub.cookies),
             proxy=self.proxy,
             cookies=self.chat_hub.cookies,
         )


### PR DESCRIPTION
When I set cookie:  throttling.maxNumUserMessagesInConversation: 20
When I call reset: throttling.maxNumUserMessagesInConversation: 10

Seems cookie get lost in in conversation.

So this commit fixed it