### PR TITLE
Fix crash when called without --history-file

### DIFF
--- a/src/EdgeGPT.py
+++ b/src/EdgeGPT.py
@@ -762,7 +762,7 @@ async def async_main(args: argparse.Namespace) -> None:
     initial_prompt = args.prompt
 
     # Log chat history
-    def p_hist():
+    def p_hist(*args, **kwargs):
         pass
     if args.history_file:
         f = open(args.history_file, 'a+')


### PR DESCRIPTION
Thank you for merging this feature but I just realized I broke the program. I'm very sorry.

I haven't done much Python so I didn't know calling a function with unexpected arguments would produce an error. I should have tested the program more. I think this fixes it but please confirm.