### PR TITLE
Fix `locationHints` being an Array

### DIFF
--- a/src/EdgeGPT.py
+++ b/src/EdgeGPT.py
@@ -337,7 +337,7 @@ class _ChatHubRequest:
                         "locale": locale,
                         "market": locale,
                         "region": locale[-2:],  # en-US -> US
-                        "locationHints": get_location_hint_from_locale(locale),
+                        "locationHints": [get_location_hint_from_locale(locale)],
                         "author": "user",
                         "inputMethod": "Keyboard",
                         "text": prompt,


### PR DESCRIPTION
I spent an unbearably long amount of time trying to find this bug, but here we go. Fixed it.

Before:
`WSMessage(type=<WSMsgType.TEXT: 1>, data='{"type":3,"invocationId":"0","error":"Failed to invoke \'chat\' due to an error on the server."}\x1e', extra='')`

After:
`<proper response>`