### PR TITLE
Fix _ChatHubRequest.update() not pass some arguments

### DIFF
--- a/src/EdgeGPT.py
+++ b/src/EdgeGPT.py
@@ -591,6 +591,9 @@ class _ChatHub:
                 prompt=prompt,
                 conversation_style=conversation_style,
                 options=options,
+                webpage_context=webpage_context,
+                search_result=search_result,
+                locale=locale,
             )
         # Send request
         await self.wss.send_str(_append_identifier(self.request.struct))


### PR DESCRIPTION
It will take some default argument to _ChatHubRequest.update function after the first ask.
So though I pass locale to Chatbot.ask, it will not pass to request
#488 