### PR TITLE
Use typing Union instead of | to support Python<3.10

### DIFF
--- a/src/EdgeGPT/EdgeUtils.py
+++ b/src/EdgeGPT/EdgeUtils.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import time
 from pathlib import Path
+from typing import Union
 
 from EdgeGPT.EdgeGPT import Chatbot
 from EdgeGPT.EdgeGPT import ConversationStyle
@@ -20,10 +21,10 @@ class Cookie:
     dirpath = Path("./").resolve()
     search_pattern = "bing_cookies_*.json"
     ignore_files = set()
-    current_filepath: dict | None = None
+    current_filepath: Union[dict, None] = None
 
     @classmethod
-    def fetch_default(cls, path: Path | None = None) -> None:
+    def fetch_default(cls, path: Union[Path, None] = None) -> None:
         from selenium import webdriver
         from selenium.webdriver.common.by import By
 
@@ -98,7 +99,7 @@ class Query:
         cookie_file: int = 0,
         echo: bool = True,
         echo_prompt: bool = False,
-        proxy: str | None = None,
+        proxy: Union[str, None] = None,
     ) -> None:
         """
         Arguments:

--- a/src/EdgeGPT/chathub.py
+++ b/src/EdgeGPT/chathub.py
@@ -30,7 +30,7 @@ class ChatHub:
         self,
         conversation: Conversation,
         proxy: str = None,
-        cookies: list[dict] | None = None,
+        cookies: Union[list[dict], None] = None,
     ) -> None:
         self.wss = None
         self.request: ChatHubRequest
@@ -73,7 +73,7 @@ class ChatHub:
         wss_link: str,
         conversation_style: CONVERSATION_STYLE_TYPE = None,
         raw: bool = False,
-        webpage_context: str | None = None,
+        webpage_context: Union[str, None] = None,
         search_result: bool = False,
         locale: str = guess_locale(),
     ) -> Generator[bool, Union[dict, str], None]:

--- a/src/EdgeGPT/conversation.py
+++ b/src/EdgeGPT/conversation.py
@@ -1,7 +1,7 @@
 import json
 import os
-
 import httpx
+from typing import Union
 
 from .constants import HEADERS_INIT_CONVER
 from .exceptions import NotAllowedToAccess
@@ -10,9 +10,9 @@ from .exceptions import NotAllowedToAccess
 class Conversation:
     def __init__(
         self,
-        proxy: str | None = None,
+        proxy: Union[str, None] = None,
         async_mode: bool = False,
-        cookies: list[dict] | None = None,
+        cookies: Union[list[dict], None] = None,
     ) -> None:
         if async_mode:
             return
@@ -66,8 +66,8 @@ class Conversation:
 
     @staticmethod
     async def create(
-        proxy: str | None = None,
-        cookies: list[dict] | None = None,
+        proxy: Union[str, None] = None,
+        cookies: Union[list[dict], None] = None,
     ) -> "Conversation":
         self = Conversation(async_mode=True)
         self.struct = {

--- a/src/EdgeGPT/request.py
+++ b/src/EdgeGPT/request.py
@@ -1,5 +1,6 @@
 import uuid
 from datetime import datetime
+from typing import Union
 
 from .conversation_style import CONVERSATION_STYLE_TYPE
 from .conversation_style import ConversationStyle
@@ -27,7 +28,7 @@ class ChatHubRequest:
         self,
         prompt: str,
         conversation_style: CONVERSATION_STYLE_TYPE,
-        webpage_context: str | None = None,
+        webpage_context: Union[str, None] = None,
         search_result: bool = False,
         locale: str = guess_locale(),
     ) -> None:

--- a/src/EdgeGPT/utilities.py
+++ b/src/EdgeGPT/utilities.py
@@ -1,6 +1,7 @@
 import json
 import locale
 import random
+from typing import Union
 
 from .constants import DELIMITER
 from .locale import LocationHint
@@ -15,7 +16,7 @@ def get_ran_hex(length: int = 32) -> str:
     return "".join(random.choice("0123456789abcdef") for _ in range(length))
 
 
-def get_location_hint_from_locale(locale: str) -> dict | None:
+def get_location_hint_from_locale(locale: str) -> Union[dict, None]:
     locale = locale.lower()
     if locale == "en-us":
         hint = LocationHint.USA.value


### PR DESCRIPTION
## Issue Description
The union operator `|` suggested in [PEP 604](https://peps.python.org/pep-0604/) is introduced to Python >= 3.10.
So this syntax is not compatible with Python < 3.10.

## Solution
Use `Union[X, Y]` to replace `X | Y`. 
See more details in Python doc for [`typing.Union`](https://docs.python.org/3/library/typing.html#typing.Union).

## Changes Example

In [`src/EdgeGPT/conversation.py`](https://github.com/acheong08/EdgeGPT/compare/master...Hansimov:EdgeGPT:master?expand=1#diff-27826ac7d93ec6328746b705345830db98a21395f484cd7ded4e26404c7dca19):
```diff
+ from typing import Union

@@ -10,9 +10,9 @@
class Conversation:
    def __init__(
        self,
--        proxy: str | None = None,
++        proxy: Union[str, None] = None,
```