### PR TITLE
Fix <RuntimeError: Event loop is closed> in windows

### DIFF
--- a/src/EdgeGPT/EdgeUtils.py
+++ b/src/EdgeGPT/EdgeUtils.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import platform
 import time
 from pathlib import Path
 from typing import Union
@@ -142,6 +143,8 @@ class Query:
             self.create_image()
 
     def log_and_send_query(self, echo: bool, echo_prompt: bool) -> None:
+        if platform.system() == "Windows":
+            asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
         self.response = asyncio.run(self.send_to_bing(echo, echo_prompt))
         name = str(Cookie.current_filepath.name)
         if not self.request_count.get(name):


### PR DESCRIPTION
## Issue Description

When use `ayncio.run()` in Windows like this:
```py
self.response = asyncio.run(self.send_to_bing(echo, echo_prompt))
```

It would raise a `RuntimeError: Event loop is closed`:

```sh
Traceback (most recent call last):
  File "C:\Python39\lib\asyncio\proactor_events.py", line 116, in __del__
    self.close()
  File "C:\Python39\lib\asyncio\proactor_events.py", line 108, in close
    self._loop.call_soon(self._call_connection_lost, None)
  File "C:\Python39\lib\asyncio\base_events.py", line 746, in call_soon
    self._check_closed()
  File "C:\Python39\lib\asyncio\base_events.py", line 510, in _check_closed
    raise RuntimeError('Event loop is closed')
RuntimeError: Event loop is closed
```

## Solution



```py
import platform
...
if platform.system() == "Windows":
    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
```

## References
* python - "Asyncio Event Loop is Closed" when getting loop - Stack Overflow
  * https://stackoverflow.com/questions/45600579/asyncio-event-loop-is-closed-when-getting-loop
* Policies — Python 3.11.3 documentation
  * https://docs.python.org/3/library/asyncio-policy.html#asyncio.WindowsSelectorEventLoopPolicy